### PR TITLE
Add CITATION.cff file and fix arxiv links

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+cff-version: 1.2.0
+message: "If you use SolarAxionFlux in your work, please cite it as below."
+authors:
+- family-names: "Hoof"
+  given-names: "Sebastian"
+  affiliation: Institut für Astrophysik, Georg-August-Universität Göttingen
+- family-names: "Thormaehlen"
+  given-names: "Lennert"
+  affiliation: Institut für theoretische Physik, Universität Heidelberg
+title: "SolarAxionFlux"
+abstract: "Library for calculating the solar axion flux for different solar models and opacity codes."
+version: v0.8b
+date-released: 2021-04-29
+url: "https://github.com/sebhoof/SolarAxionFlux"

--- a/README.md
+++ b/README.md
@@ -75,28 +75,28 @@ You may also consider using the [BibCom tool](https://github.com/sebhoof/bibcom)
 
 ### Our code and results
 
-When you make use of our code, please **link to this Github project** and cite [arXiv:2101.08789](https://arxiv.org/astro-ph/abs/2101.08789) (BibTeX entries available from e.g. [ADS](https://ui.adsabs.harvard.edu/abs/2021JCAP...09..006H/exportcitation) or [INSPIRE](https://inspirehep.net/literature/1842437), or [references.bib](references.bib)).
+When you make use of our code, please **link to this Github project** and cite [arXiv:2101.08789](https://arxiv.org/abs/2101.08789) (BibTeX entries available from e.g. [ADS](https://ui.adsabs.harvard.edu/abs/2021JCAP...09..006H/exportcitation) or [INSPIRE](https://inspirehep.net/literature/1842437), or [references.bib](references.bib)).
 
-* If you use the flux from nuclear transitions, please also cite [arXiv:2111.06407](https://arxiv.org/astro-ph/abs/2111.06407) (BibTeX entries available from e.g. [ADS](https://ui.adsabs.harvard.edu/abs/2022EPJC...82..120D/exportcitation), [INSPIRE](https://inspirehep.net/literature/1967014), or [references.bib](references.bib)).
+* If you use the flux from nuclear transitions, please also cite [arXiv:2111.06407](https://arxiv.org/abs/2111.06407) (BibTeX entries available from e.g. [ADS](https://ui.adsabs.harvard.edu/abs/2022EPJC...82..120D/exportcitation), [INSPIRE](https://inspirehep.net/literature/1967014), or [references.bib](references.bib)).
 
 * If you use the Python scripts contained in [python](python/), please also cite our arXiv preprint (TBA).
 
 ### Solar models
 
-* BP98 [arXiv:astro-ph/9805135](https://arxiv.org/astro-ph/abs/astro-ph/9805135)
-* BP00 [arXiv:astro-ph/0010346](https://arxiv.org/astro-ph/abs/astro-ph/0010346)
-* BP04 [arXiv:astro-ph/0402114](https://arxiv.org/astro-ph/abs/astro-ph/0402114)
-* BS05-OP, BS05-AGSOP [arXiv:astro-ph/0412440](https://arxiv.org/astro-ph/abs/astro-ph/0412440)
-* AGS05 [arXiv:0909.2668](https://arxiv.org/astro-ph/abs/0909.2668)
-* GS98, AGSS09(met), AGSS09ph [arXiv:0909.2668](https://arxiv.org/astro-ph/abs/0909.2668), [arXiv:0910.3690](https://arxiv.org/astro-ph/abs/0910.3690)
-* B16-GS98, B16-AGSS09 [arXiv:1611.09867](https://arxiv.org/astro-ph/abs/1611.09867)
+* BP98 [arXiv:astro-ph/9805135](https://arxiv.org/abs/astro-ph/9805135)
+* BP00 [arXiv:astro-ph/0010346](https://arxiv.org/abs/astro-ph/0010346)
+* BP04 [arXiv:astro-ph/0402114](https://arxiv.org/abs/astro-ph/0402114)
+* BS05-OP, BS05-AGSOP [arXiv:astro-ph/0412440](https://arxiv.org/abs/astro-ph/0412440)
+* AGS05 [arXiv:0909.2668](https://arxiv.org/abs/0909.2668)
+* GS98, AGSS09(met), AGSS09ph [arXiv:0909.2668](https://arxiv.org/abs/0909.2668), [arXiv:0910.3690](https://arxiv.org/abs/0910.3690)
+* B16-GS98, B16-AGSS09 [arXiv:1611.09867](https://arxiv.org/abs/1611.09867)
 
 ### Opacities
 
 * LEDCOP [APS Conf. Series **75** (1995)](https://ui.adsabs.harvard.edu/abs/1995ASPC...78...51M)
-* OP [arXiv:astro-ph/0410744](https://arxiv.org/astro-ph/abs/astro-ph/0410744), [arXiv:astro-ph/0411010](https://arxiv.org/astro-ph/abs/astro-ph/0411010)
+* OP [arXiv:astro-ph/0410744](https://arxiv.org/abs/astro-ph/0410744), [arXiv:astro-ph/0411010](https://arxiv.org/abs/astro-ph/0411010)
 * OPAS [ApJ **754** 1 (1012)](https://doi.org/10.1088/0004-637X/745/1/10), [ApJ Suppl. Series **220** 1 (1015)](https://doi.org/10.1088/0067-0049/220/1/2)
-* ATOMIC [arXiv:1601.01005](https://arxiv.org/astro-ph/abs/1601.01005)
+* ATOMIC [arXiv:1601.01005](https://arxiv.org/abs/1601.01005)
 
 ## Troubleshooting
 Note that some fixes require running `make clean` or deleting the contents of your `build/` directory in order to take effect/be recognised by the CMAKE system.


### PR DESCRIPTION
Hey,

not sure if you recognize this handle, but we've talked at a few IAXO collaboration meetings in the past (Sebastian from Bonn).

I just wanted to cite your repository for my thesis (independent of the paper) and noticed there isn't a CITATION file. Adding one means there's automatically a button on Github on the side bar (where the README, activity, stars etc buttons are) to get the citation in the format of choice.

Example here: https://github.com/SciNim/xrayAttenuation

Github docs here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files

I'm not sure if the data I put in there is accurate. I used `v0.8b` as the version, because that is the one mentioned in the paper (and hence your institution @sebhoof; I noticed on the newer paper you have two different institutions assigned).

While looking at the README I also noticed a bunch of arxiv links are broken (was that format ever allowed?). 

#### On an unrelated note:

I saw your latest preprint (about axion helioscopes as "solar thermometers"). While I've only had a _very quick_ glance at it, first of all it's an interesting concept (for the ambitious among us ;) ). In any case, you mention the uncertainty of the X-ray optics in the whole. From my side I would expect that to be almost the biggest trouble in all this (having just spent another few more weeks related to raytracing the LLNL telescope used at CAST). 

However, it seems doable to use a raytracer like https://github.com/Vindaar/TrAXer to do this. I imagine one could effectively do gradient descent to backpropagate from the image to a matching axion emission. Ideally, this could even be done using automatic differentiation. I remember some Zygote.jl example about inverse rendering; while googling for it I found something even more applicable in a sense 

- https://github.com/avik-pal/RayTracer.jl
- https://arxiv.org/abs/1907.07198

(I imagine applying that to the axion problem would be tricky due to the solar emission being a rather non standard thing in terms of raytracers, let alone X-ray reflectivities).

In my raytracing code I linked I suppose it should be feasible to do inverse rendering at least if one bases it on dual number autograd. To do source code transformation like Zyogte.jl to generate the backward pass is - uhm - more tricky obviously. Anyway, computing the numerical derivative is not a problem for sure though.

Just food for thought!